### PR TITLE
add possibility to add a customstylemap to a textBody

### DIFF
--- a/src/components/SimpleBlocks/TextBody.jsx
+++ b/src/components/SimpleBlocks/TextBody.jsx
@@ -117,6 +117,7 @@ const TextBody = props => {
             }
             blockStyleFn={settings.blockStyleFn}
             placeholder={intl.formatMessage(messages.text)}
+            customStyleMap={settings.customStyleMap}
           />
           {!noRichText && <InlineToolbar />}
         </>


### PR DESCRIPTION
This adds the ability to add customStyleMaps. If no customStyleMap is supplied it still works fine.
See this PR on how to use it: https://github.com/kitconcept/talke-karriere/pull/37