### PR TITLE
Change the import file for the DetachedTextBlockEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 ### Internal
+- Changing the import file for the DetachedTextBlockEditor @iFlameing
 
 ## 9.2.0 (2021-11-29)
 

--- a/src/components/TextPill/Edit.jsx
+++ b/src/components/TextPill/Edit.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SidebarPortal } from '@plone/volto/components';
 import Sidebar from './Sidebar';
-import { DetachedTextBlockEditor } from 'volto-slate/blocks/Text/TextBlockEdit';
+import DetachedTextBlockEditor from 'volto-slate/blocks/Text/DetachedTextBlockEditor';
 
 const TextPillEdit = (props) => {
   const { data, onChangeBlock, block, selected } = props;


### PR DESCRIPTION
A new version of volto-slate 5.1.2 changes the export of DetachedTextBlockEditor. So I created this pr to incorporate with the latest changes.