### PR TITLE
Implement ImgLoader component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Implement ImgLoader component @reebalazs
+
 ### Bugfix
 
 ### Internal

--- a/src/components/ImageLoader/AnyLoader.jsx
+++ b/src/components/ImageLoader/AnyLoader.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+
+/*
+
+Base component for creating image loaders. Should not be used
+directly. Instead, it can be used to create a new loader element.
+
+```jsx
+<AnyLoader {...}
+  createElememt={createElement}
+  placeholder={[placeholder image or svg]}
+>
+  ...
+</AnyLoader>
+```
+
+The createElement property must be a function that creates the
+loading element. The function has the same signature as
+React.createElement. The function must in particular, handle the
+onLoad property passed to it and make sure that onLoad is called
+when the created element has been loaded.
+
+This can be adapted to any specific image loader class. Examples
+provided are:
+
+- ImgLoader.jsx for loading an html img element
+- ImageLoader.jsx for loading a React Semantic UI Image element
+
+*/
+
+export default (props) => {
+  const { children, createComponent, placeholder, ...imgProps } = props;
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [placeholderProps, setPlaceholderProps] = useState({});
+  const [placeholderChildren, setPlaceholderChildren] = useState(undefined);
+  if (isLoaded && imgProps.src !== placeholderProps.src) {
+    setIsLoaded(false);
+  }
+  const onLoad = () => {
+    setIsLoaded(true);
+    setPlaceholderProps(imgProps);
+    setPlaceholderChildren(children);
+  };
+  return (
+    <>
+      {isLoaded ? (
+        createComponent(imgProps, children)
+      ) : (
+        <div style={{ display: 'none' }}>
+          {imgProps.src
+            ? createComponent({ ...imgProps, onLoad }, children)
+            : null}
+        </div>
+      )}
+      {isLoaded
+        ? null
+        : placeholderProps.src
+        ? createComponent(placeholderProps, placeholderChildren)
+        : placeholder}
+    </>
+  );
+};

--- a/src/components/ImageLoader/AnyLoader.test.jsx
+++ b/src/components/ImageLoader/AnyLoader.test.jsx
@@ -1,0 +1,444 @@
+import React from 'react';
+import { create, act } from 'react-test-renderer';
+import AnyLoader from './AnyLoader';
+
+export const describeAnyLoader = ({ Component, expectComponent }) => {
+  test('shows placeholder, then shows loaded image', () => {
+    const component = create(
+      <Component
+        src="http://foo.bar/image"
+        alt="DESCRIPTION"
+        placeholder={
+          <>
+            <div foo1="bar1" />
+            <div foo2="bar2" />
+          </>
+        }
+      ></Component>,
+    );
+    const loading = component.toJSON();
+    expect(loading.length).toBe(3);
+    expect(loading[0].props.style.display).toBe('none');
+    expect(loading[1].props.foo1).toBe('bar1');
+    expect(loading[2].props.foo2).toBe('bar2');
+    expect(loading[0].children.length).toBe(1);
+    const img = loading[0].children[0];
+    expectComponent(img, {
+      src: 'http://foo.bar/image',
+      alt: 'DESCRIPTION',
+    });
+    act(() => {
+      img.props.onLoad();
+    });
+    const loaded = component.toJSON();
+    expectComponent(loaded, {
+      src: 'http://foo.bar/image',
+      alt: 'DESCRIPTION',
+    });
+  });
+
+  test('shows placeholder single child, then shows loaded image', () => {
+    const component = create(
+      <Component
+        src="http://foo.bar/image"
+        alt="DESCRIPTION"
+        placeholder={<div foo1="bar1" />}
+      ></Component>,
+    );
+    const loading = component.toJSON();
+    expect(loading.length).toBe(2);
+    expect(loading[0].props.style.display).toBe('none');
+    expect(loading[1].props.foo1).toBe('bar1');
+    expect(loading[0].children.length).toBe(1);
+    const img = loading[0].children[0];
+    expectComponent(img, {
+      src: 'http://foo.bar/image',
+      alt: 'DESCRIPTION',
+    });
+    act(() => {
+      img.props.onLoad();
+    });
+    const loaded = component.toJSON();
+    expectComponent(loaded, {
+      src: 'http://foo.bar/image',
+      alt: 'DESCRIPTION',
+    });
+  });
+
+  describe('shows placeholder if src is missing', () => {
+    const testWithSrc = (src) => {
+      const component = create(
+        <Component
+          src={src}
+          alt="DESCRIPTION"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        ></Component>,
+      );
+      const placeholder = component.toJSON();
+      expect(placeholder.length).toBe(3);
+      expect(placeholder[0].props.style.display).toBe('none');
+      expect(placeholder[1].props.foo1).toBe('bar1');
+      expect(placeholder[2].props.foo2).toBe('bar2');
+      expect(placeholder[0].children).toBe(null);
+    };
+
+    test('null string', () => {
+      testWithSrc('');
+    });
+
+    test('null', () => {
+      testWithSrc(null);
+    });
+
+    test('undefined or missing', () => {
+      testWithSrc(undefined);
+    });
+
+    test('false', () => {
+      testWithSrc(false);
+    });
+  });
+
+  describe('can update src', () => {
+    test('from placeholder', () => {
+      const component = create(
+        <Component
+          src=""
+          alt="DESCRIPTION"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        ></Component>,
+      );
+      const placeholder = component.toJSON();
+      expect(placeholder.length).toBe(3);
+      expect(placeholder[0].props.style.display).toBe('none');
+      expect(placeholder[1].props.foo1).toBe('bar1');
+      expect(placeholder[2].props.foo2).toBe('bar2');
+      expect(placeholder[0].children).toBe(null);
+      act(() => {
+        component.update(
+          <Component
+            src="http://foo.bar/image"
+            alt="DESCRIPTION"
+            placeholder={
+              <>
+                <div foo1="bar1" />
+                <div foo2="bar2" />
+              </>
+            }
+          ></Component>,
+        );
+      });
+      const loading = component.toJSON();
+      expect(loading.length).toBe(3);
+      expect(loading[0].props.style.display).toBe('none');
+      expect(loading[1].props.foo1).toBe('bar1');
+      expect(loading[2].props.foo2).toBe('bar2');
+      expect(loading[0].children.length).toBe(1);
+      const img = loading[0].children[0];
+      expect(img.props.src).toBe('http://foo.bar/image');
+      expect(img.props.alt).toBe('DESCRIPTION');
+      expect('children' in img.props).toBe(false);
+      expect(img.children).toBe(null);
+      act(() => {
+        img.props.onLoad();
+      });
+      const loaded = component.toJSON();
+      expectComponent(loaded, {
+        src: 'http://foo.bar/image',
+        alt: 'DESCRIPTION',
+      });
+    });
+
+    test('from other src', () => {
+      const component = create(
+        <Component
+          src="http://foo.bar/image1"
+          alt="DESCRIPTION1"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        ></Component>,
+      );
+      const loading = component.toJSON();
+      expect(loading.length).toBe(3);
+      expect(loading[0].props.style.display).toBe('none');
+      expect(loading[1].props.foo1).toBe('bar1');
+      expect(loading[2].props.foo2).toBe('bar2');
+      expect(loading[0].children.length).toBe(1);
+      const img = loading[0].children[0];
+      expect(img.type).toBe('img');
+      expect(img.props.src).toBe('http://foo.bar/image1');
+      expect(img.props.alt).toBe('DESCRIPTION1');
+      expect('children' in img.props).toBe(false);
+      expect(img.children).toBe(null);
+      act(() => {
+        img.props.onLoad();
+      });
+      const loaded1 = component.toJSON();
+      expectComponent(loaded1, {
+        src: 'http://foo.bar/image1',
+        alt: 'DESCRIPTION1',
+      });
+      act(() => {
+        component.update(
+          <Component
+            src="http://foo.bar/image2"
+            alt="DESCRIPTION2"
+            placeholder={
+              <>
+                <div foo1="bar1" />
+                <div foo2="bar2" />
+              </>
+            }
+          ></Component>,
+        );
+      });
+      const updating = component.toJSON();
+      expect(updating.length).toBe(2);
+      expect(updating[0].props.style.display).toBe('none');
+      expect(updating[1].type).toBe('img');
+      expect(updating[1].props.src).toBe('http://foo.bar/image1');
+      expect(updating[1].props.alt).toBe('DESCRIPTION1');
+      expect(updating[0].children.length).toBe(1);
+      const img2 = updating[0].children[0];
+      expect(img2.props.src).toBe('http://foo.bar/image2');
+      expect(img2.props.alt).toBe('DESCRIPTION2');
+      expect('children' in img2.props).toBe(false);
+      expect(img2.children).toBe(null);
+      act(() => {
+        img2.props.onLoad();
+      });
+      const loaded2 = component.toJSON();
+      expectComponent(loaded2, {
+        src: 'http://foo.bar/image2',
+        alt: 'DESCRIPTION2',
+      });
+    });
+  });
+
+  describe('can update other props than src', () => {
+    test('from placeholder', () => {
+      const component = create(
+        <Component
+          src=""
+          alt="DESCRIPTION"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        ></Component>,
+      );
+      const placeholder = component.toJSON();
+      expect(placeholder.length).toBe(3);
+      expect(placeholder[0].props.style.display).toBe('none');
+      expect(placeholder[1].props.foo1).toBe('bar1');
+      expect(placeholder[2].props.foo2).toBe('bar2');
+      expect(placeholder[0].children).toBe(null);
+      act(() => {
+        component.update(
+          <Component
+            src=""
+            alt="DESCRIPTION2"
+            placeholder={
+              <>
+                <div foo1="bar1" />
+                <div foo2="bar2" />
+              </>
+            }
+          ></Component>,
+        );
+      });
+      const placeholder2 = component.toJSON();
+      expect(placeholder2.length).toBe(3);
+      expect(placeholder2[0].props.style.display).toBe('none');
+      expect(placeholder2[1].props.foo1).toBe('bar1');
+      expect(placeholder2[2].props.foo2).toBe('bar2');
+      expect(placeholder2[0].children).toBe(null);
+    });
+
+    test('from other src', () => {
+      const component = create(
+        <Component
+          src="http://foo.bar/image1"
+          alt="DESCRIPTION1"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        ></Component>,
+      );
+      const loading = component.toJSON();
+      expect(loading.length).toBe(3);
+      expect(loading[0].props.style.display).toBe('none');
+      expect(loading[1].props.foo1).toBe('bar1');
+      expect(loading[2].props.foo2).toBe('bar2');
+      expect(loading[0].children.length).toBe(1);
+      const img = loading[0].children[0];
+      expect(img.type).toBe('img');
+      expect(img.props.src).toBe('http://foo.bar/image1');
+      expect(img.props.alt).toBe('DESCRIPTION1');
+      expect('children' in img.props).toBe(false);
+      expect(img.children).toBe(null);
+      act(() => {
+        img.props.onLoad();
+      });
+      const loaded1 = component.toJSON();
+      expectComponent(loaded1, {
+        src: 'http://foo.bar/image1',
+        alt: 'DESCRIPTION1',
+      });
+      act(() => {
+        component.update(
+          <Component
+            src="http://foo.bar/image1"
+            alt="DESCRIPTION2"
+            placeholder={
+              <>
+                <div foo1="bar1" />
+                <div foo2="bar2" />
+              </>
+            }
+          ></Component>,
+        );
+      });
+      const loaded2 = component.toJSON();
+      expectComponent(loaded2, {
+        src: 'http://foo.bar/image1',
+        alt: 'DESCRIPTION2',
+      });
+    });
+  });
+
+  describe('can update placeholder', () => {
+    test('from placeholder, update becomes visible', () => {
+      const component = create(
+        <Component
+          src=""
+          alt="DESCRIPTION"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        ></Component>,
+      );
+      const placeholder = component.toJSON();
+      expect(placeholder.length).toBe(3);
+      expect(placeholder[0].props.style.display).toBe('none');
+      expect(placeholder[1].props.foo1).toBe('bar1');
+      expect(placeholder[2].props.foo2).toBe('bar2');
+      expect(placeholder[0].children).toBe(null);
+      act(() => {
+        component.update(
+          <Component
+            src=""
+            alt="DESCRIPTION"
+            placeholder={
+              <>
+                <div foo3="bar3" />
+                <div foo4="bar4" />
+              </>
+            }
+          ></Component>,
+        );
+      });
+      const placeholder2 = component.toJSON();
+      expect(placeholder2.length).toBe(3);
+      expect(placeholder2[0].props.style.display).toBe('none');
+      expect(placeholder2[1].props.foo3).toBe('bar3');
+      expect(placeholder2[2].props.foo4).toBe('bar4');
+      expect(placeholder2[0].children).toBe(null);
+    });
+
+    test('from other src, no change', () => {
+      const component = create(
+        <Component
+          src="http://foo.bar/image"
+          alt="DESCRIPTION"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        ></Component>,
+      );
+      const loading = component.toJSON();
+      expect(loading.length).toBe(3);
+      expect(loading[0].props.style.display).toBe('none');
+      expect(loading[1].props.foo1).toBe('bar1');
+      expect(loading[2].props.foo2).toBe('bar2');
+      expect(loading[0].children.length).toBe(1);
+      const img = loading[0].children[0];
+      expect(img.type).toBe('img');
+      expect(img.props.src).toBe('http://foo.bar/image');
+      expect(img.props.alt).toBe('DESCRIPTION');
+      expect('children' in img.props).toBe(false);
+      expect(img.children).toBe(null);
+      act(() => {
+        img.props.onLoad();
+      });
+      const loaded1 = component.toJSON();
+      expectComponent(loaded1, {
+        src: 'http://foo.bar/image',
+        alt: 'DESCRIPTION',
+      });
+      act(() => {
+        component.update(
+          <Component
+            src="http://foo.bar/image"
+            alt="DESCRIPTION"
+            placeholder={
+              <>
+                <div foo3="bar3" />
+                <div foo4="bar4" />
+              </>
+            }
+          ></Component>,
+        );
+      });
+      const loaded2 = component.toJSON();
+      expectComponent(loaded2, {
+        src: 'http://foo.bar/image',
+        alt: 'DESCRIPTION',
+      });
+    });
+  });
+};
+
+describe('AnyLoader', () => {
+  describeAnyLoader({
+    Component: (props) =>
+      AnyLoader({
+        ...props,
+        createComponent: (props, children) =>
+          React.createElement('img', props, children),
+      }),
+    expectComponent: (img, props) => {
+      expect(img.type).toBe('img');
+      for (const k in props) {
+        expect(img.props[k]).toBe(props[k]);
+      }
+      expect('children' in img.props).toBe(false);
+      expect(img.children).toBe(null);
+    },
+  });
+});

--- a/src/components/ImageLoader/ImageLoader.jsx
+++ b/src/components/ImageLoader/ImageLoader.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Grid, Image, Button } from 'semantic-ui-react';
+import AnyLoader from './AnyLoader';
+
+/*
+
+A React component ImageLoader. Loads a semantic UI image.
+
+```jsx
+<ImageLoader
+  src={
+    member?.image_field
+      ? flattenToAppURL(
+          `${member['@id']}/@@images/${member.image_field}/preview`,
+        )
+      : avatarPlaceholderPNG
+  }
+  size="small"
+  avatar
+  placeholder={
+    <Image
+      src="avatarPlaceholderPNG"
+      size="small"
+      avatar
+    />
+  }
+/>
+```
+
+This will become a react-semantic-ui Image with all the parameters specified in the ImageLoader props.
+Before the image is loaded, it will show the component from the
+placeholder property.
+
+The placeholder property can be a single element or a list of
+elements defined with <>...</>.
+
+If the src component is empty, the image is not loaded and
+the placeholder will be permanently shown. This makes it possible
+to apply a condition in the src attribute.
+
+As the semantic UI Image tag is allowed to have children,
+ImageLoader also supports to have children, and they will behave as if they were children of the semantic UI Image tag. The children will only appear when the image has been loaded.
+*/
+
+export default (props) =>
+  AnyLoader({
+    ...props,
+    createComponent: (props, children) =>
+      React.createElement(Image, props, children),
+  });

--- a/src/components/ImageLoader/ImageLoader.test.jsx
+++ b/src/components/ImageLoader/ImageLoader.test.jsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { create, act } from 'react-test-renderer';
+import ImageLoader from './ImageLoader';
+import { describeAnyLoader } from './AnyLoader.test';
+
+describe('ImageLoader', () => {
+  describeAnyLoader({
+    Component: ImageLoader,
+    expectComponent: (img, props) => {
+      expect(img.type).toBe('img');
+      for (const k in props) {
+        expect(img.props[k]).toBe(props[k]);
+      }
+      expect('children' in img.props).toBe(false);
+      expect(img.children).toBe(null);
+    },
+  });
+
+  const expectComponent = (img, props) => {
+    expect(img.type).toBe('div');
+    for (const k in props) {
+      expect(img.props[k]).toBe(props[k]);
+    }
+    expect('children' in img.props).toBe(false);
+  };
+
+  test('loaded image can have children', () => {
+    const component = create(
+      <ImageLoader
+        src="http://foo.bar/image"
+        alt="DESCRIPTION"
+        placeholder={
+          <>
+            <div foo1="bar1" />
+            <div foo2="bar2" />
+          </>
+        }
+      >
+        <div foo3="bar3" />
+        <div foo4="bar4" />
+      </ImageLoader>,
+    );
+    const loading = component.toJSON();
+    expect(loading.length).toBe(3);
+    expect(loading[0].props.style.display).toBe('none');
+    expect(loading[1].props.foo1).toBe('bar1');
+    expect(loading[2].props.foo2).toBe('bar2');
+    expect(loading[0].children.length).toBe(1);
+    const img = loading[0].children[0];
+    expectComponent(img, {
+      src: 'http://foo.bar/image',
+      alt: 'DESCRIPTION',
+    });
+    const children = img.children;
+    expect(children.length).toBe(2);
+    expect(children[0].props.foo3).toBe('bar3');
+    expect(children[1].props.foo4).toBe('bar4');
+    act(() => {
+      img.props.onLoad();
+    });
+    const loaded = component.toJSON();
+    expectComponent(loaded, {
+      src: 'http://foo.bar/image',
+      alt: 'DESCRIPTION',
+    });
+    const loadedChildren = loaded.children;
+    expect(loadedChildren.length).toBe(2);
+    expect(loadedChildren[0].props.foo3).toBe('bar3');
+    expect(loadedChildren[1].props.foo4).toBe('bar4');
+  });
+
+  test('can update children', () => {
+    const component = create(
+      <ImageLoader
+        src="http://foo.bar/image1"
+        alt="DESCRIPTION1"
+        placeholder={
+          <>
+            <div foo1="bar1" />
+            <div foo2="bar2" />
+          </>
+        }
+      >
+        <div foo3="bar3" />
+        <div foo4="bar4" />
+      </ImageLoader>,
+    );
+    const loading = component.toJSON();
+    expect(loading.length).toBe(3);
+    expect(loading[0].props.style.display).toBe('none');
+    expect(loading[1].props.foo1).toBe('bar1');
+    expect(loading[2].props.foo2).toBe('bar2');
+    expect(loading[0].children.length).toBe(1);
+    const img = loading[0].children[0];
+    expectComponent(img, {
+      src: 'http://foo.bar/image1',
+      alt: 'DESCRIPTION1',
+    });
+    const children = img.children;
+    expect(children.length).toBe(2);
+    expect(children[0].props.foo3).toBe('bar3');
+    expect(children[1].props.foo4).toBe('bar4');
+    act(() => {
+      img.props.onLoad();
+    });
+    const loaded1 = component.toJSON();
+    expectComponent(loaded1, {
+      src: 'http://foo.bar/image1',
+      alt: 'DESCRIPTION1',
+    });
+    act(() => {
+      component.update(
+        <ImageLoader
+          src="http://foo.bar/image2"
+          alt="DESCRIPTION2"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        >
+          <div foo5="bar5" />
+          <div foo6="bar6" />
+        </ImageLoader>,
+      );
+    });
+    const updating = component.toJSON();
+    expect(updating.length).toBe(2);
+    expect(updating[0].props.style.display).toBe('none');
+    const placeholderImg = updating[1];
+    expectComponent(placeholderImg, {
+      src: 'http://foo.bar/image1',
+      alt: 'DESCRIPTION1',
+    });
+    const childrenP = placeholderImg.children;
+    expect(childrenP.length).toBe(2);
+    expect(childrenP[0].props.foo3).toBe('bar3');
+    expect(childrenP[1].props.foo4).toBe('bar4');
+    const img2 = updating[0].children[0];
+    expectComponent(img2, {
+      src: 'http://foo.bar/image2',
+      alt: 'DESCRIPTION2',
+    });
+    const children2 = img2.children;
+    expect(children2.length).toBe(2);
+    expect(children2[0].props.foo5).toBe('bar5');
+    expect(children2[1].props.foo6).toBe('bar6');
+    act(() => {
+      img2.props.onLoad();
+    });
+    const loaded2 = component.toJSON();
+    expectComponent(loaded2, {
+      src: 'http://foo.bar/image2',
+      alt: 'DESCRIPTION2',
+    });
+    const childrenL2 = loaded2.children;
+    expect(childrenL2.length).toBe(2);
+    expect(childrenL2[0].props.foo5).toBe('bar5');
+    expect(childrenL2[1].props.foo6).toBe('bar6');
+  });
+});

--- a/src/components/ImageLoader/ImgLoader.jsx
+++ b/src/components/ImageLoader/ImgLoader.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import AnyLoader from './AnyLoader';
+
+/*
+
+A React component ImgLoader.
+
+```jsx
+<ImgLoader {...}
+  placeholder={[placeholder image or svg]}
+/>
+```
+
+This will become an img with all the parameters specified in the ImgLoader props.
+Before the image is loaded, it will show the component from the
+placeholder property.
+
+The placeholder property can be a single element or a list of
+elements defined with <>...</>.
+
+If the src component is empty, the image is not loaded and
+the placeholder will be permanently shown. This makes it possible
+to apply a condition in the src attribute.
+
+ImgLoader cannot have children, as <img> is not allowed to have
+children.
+
+
+Example for png:
+
+```jsx
+<ImgLoader
+  src={hasImage && flattenToAppURL(
+    content.image.scales.teaser.download,
+  )}
+  alt={content.title}
+  placeholder={<img src={personDummyPNG} alt={content.title} />}
+/>
+```
+
+Example for svg:
+
+```jsx
+<ImgLoader
+  src={item.image_field && flattenToAppURL(
+    `${item['@id']}/@@images/${item.image_field}/preview`,
+  )}
+  alt={item.title}
+  placeholder={<SomeSvg />}
+/>
+```
+
+Example for Volto icon:
+
+```jsx
+<ImgLoader
+  src={hasImage && flattenToAppURL(
+    content.image.scales.teaser.download,
+  )}
+  alt={content.title}
+  placeholder={(
+    <Icon
+      name={ploneSVG}
+      size="20px"
+      color="#007EB1"
+      title={'plone-svg'}
+     />
+   )}
+/>
+```
+
+#Future improvement
+
+Add blurHash as placeholder. Blurhash is a separate development effort. The blurhash can be added as placeholder. This will involve creating a new content type (or an adapter). _Not in the current scope._
+
+ */
+
+export default (props) =>
+  AnyLoader({
+    ...props,
+    createComponent: (props, children) => {
+      if (children !== undefined) {
+        throw new Error('Children are not allowed in <ImgLoader>');
+      }
+      return React.createElement('img', props);
+    },
+  });

--- a/src/components/ImageLoader/ImgLoader.test.jsx
+++ b/src/components/ImageLoader/ImgLoader.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { create, act } from 'react-test-renderer';
+import ImgLoader from './ImgLoader';
+import { describeAnyLoader } from './AnyLoader.test';
+
+describe('ImgLoader', () => {
+  describeAnyLoader({
+    Component: ImgLoader,
+    expectComponent: (img, props) => {
+      expect(img.type).toBe('img');
+      for (const k in props) {
+        expect(img.props[k]).toBe(props[k]);
+      }
+      expect('children' in img.props).toBe(false);
+      expect(img.children).toBe(null);
+    },
+  });
+
+  const expectComponent = (img, props) => {
+    expect(img.type).toBe('img');
+    for (const k in props) {
+      expect(img.props[k]).toBe(props[k]);
+    }
+    expect('children' in img.props).toBe(false);
+    expect(img.children).toBe(null);
+  };
+
+  test('Not allowed to have children', () => {
+    spyOn(console, 'error');
+    expect(() =>
+      create(
+        <ImgLoader
+          src="http://foo.bar/image"
+          alt="DESCRIPTION"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        >
+          <div fooC="barC" />
+        </ImgLoader>,
+      ),
+    ).toThrow('Children are not allowed in <ImgLoader>');
+  });
+});

--- a/src/components/ImageLoader/index.js
+++ b/src/components/ImageLoader/index.js
@@ -1,0 +1,2 @@
+export ImgLoader from './ImgLoader';
+export ImageLoader from './ImageLoader';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -41,6 +41,8 @@ import QuerystringSidebarWidget from '@kitconcept/volto-blocks/components/Widget
 import EffectiveDate from '@kitconcept/volto-blocks/components/EffectiveDate/EffectiveDate';
 import DisplayI18nDate from '@kitconcept/volto-blocks/components/DisplayI18nDate/DisplayI18nDate';
 
+import { ImgLoader, ImageLoader } from './ImageLoader';
+
 export {
   ImagesGridIconsVariation,
   DragDropList,
@@ -81,4 +83,6 @@ export {
   QuerystringSidebarWidget,
   EffectiveDate,
   DisplayI18nDate,
+  ImgLoader,
+  ImageLoader,
 };


### PR DESCRIPTION
A pattern to load an image component with a placeholder.

Includes:

- an Anyloader component that can be used to create a wrapper for any
  specific image component.

Specific wrappers implemented:

- ImgLoader to load a html img component
- ImageLoader to load a Semantic UI Image component

In both cases the `placeholder` property must be specified to define
the placeholder content. This is typically an svg or any other html
markup that can be displayed until the image is loaded.

Similarly, a lightweight wrapper can be created to support any specific
image component by using the AnyLoader component.