### PR TITLE
Fix ImgLoader loading with SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix ImgLoader loading with SSR @reebalazs
+
 ### Internal
 
 ## 11.0.1 (2022-06-13)

--- a/src/components/ImageLoader/AnyLoader.jsx
+++ b/src/components/ImageLoader/AnyLoader.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 
 /*
 
@@ -31,16 +31,30 @@ provided are:
 export default (props) => {
   const { children, createComponent, placeholder, ...imgProps } = props;
   const [isLoaded, setIsLoaded] = useState(false);
+  const ref = useRef();
   const [placeholderProps, setPlaceholderProps] = useState({});
   const [placeholderChildren, setPlaceholderChildren] = useState(undefined);
-  if (isLoaded && imgProps.src !== placeholderProps.src) {
-    setIsLoaded(false);
-  }
-  const onLoad = () => {
+  const onLoad = useCallback(() => {
     setIsLoaded(true);
     setPlaceholderProps(imgProps);
     setPlaceholderChildren(children);
-  };
+  }, [imgProps, children]);
+  useEffect(() => {
+    console.log('XXX', ref.current, ref.current?.complete);
+    if (ref.current?.complete) {
+      console.log('THIS ONLOAD');
+      onLoad();
+    }
+    if (isLoaded && imgProps.src !== placeholderProps.src) {
+      setIsLoaded(false);
+    }
+  }, [
+    isLoaded,
+    imgProps.src,
+    placeholderProps.src,
+    ref.current?.complete,
+    onLoad,
+  ]);
   return (
     <>
       {isLoaded ? (
@@ -48,7 +62,7 @@ export default (props) => {
       ) : (
         <div style={{ display: 'none' }}>
           {imgProps.src
-            ? createComponent({ ...imgProps, onLoad }, children)
+            ? createComponent({ ...imgProps, onLoad, ref }, children)
             : null}
         </div>
       )}

--- a/src/components/ImageLoader/ImageLoader.jsx
+++ b/src/components/ImageLoader/ImageLoader.jsx
@@ -45,5 +45,11 @@ export default (props) =>
   AnyLoader({
     ...props,
     createComponent: (props, children) =>
-      React.createElement(Image, props, children),
+      React.createElement(
+        React.forwardRef((props, ref) =>
+          React.createElement(Image, props, children),
+        ),
+        props,
+        children,
+      ),
   });


### PR DESCRIPTION
Isomorphic rendering requires also to check the completed property of
the image. This has to be adapted differently for the <img> and for the
semantic-ui <Image> components.