### PR TITLE
imageloader support lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Support lazy loading in the imageloader #277 @reebalazs
+- Allow blurhash prop to override placeholder prop in the imageloader #276 @reebalazs
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Support lazy loading in the imageloader #277 @reebalazs
+
 ### Internal
 
 ## 12.2.0 (2022-08-24)

--- a/src/components/ImageLoader/AnyLoader.jsx
+++ b/src/components/ImageLoader/AnyLoader.jsx
@@ -64,10 +64,12 @@ export default (props) => {
       {isLoaded ? (
         createComponent(imgProps, children)
       ) : (
-        <div style={{ display: 'none' }}>
-          {imgProps.src
-            ? createComponent({ ...imgProps, onLoad, ref }, children)
-            : null}
+        <div style={{ position: 'relative' }}>
+          <div style={{ position: 'absolute', visibility: 'hidden' }}>
+            {imgProps.src
+              ? createComponent({ ...imgProps, onLoad, ref }, children)
+              : null}
+          </div>
         </div>
       )}
       {isLoaded

--- a/src/components/ImageLoader/AnyLoader.test.jsx
+++ b/src/components/ImageLoader/AnyLoader.test.jsx
@@ -2,6 +2,18 @@ import React from 'react';
 import { create, act } from 'react-test-renderer';
 import AnyLoader from './AnyLoader';
 
+export const expectWrapper = (wrapper) => {
+  expect(wrapper.props.style).toEqual({ position: 'relative' });
+  expect(wrapper.children.length).toBe(1);
+  expect(wrapper.children[0].props.style).toEqual({
+    position: 'absolute',
+    visibility: 'hidden',
+  });
+  const children = wrapper.children[0].children;
+  expect(!children || children.length === 1).toBe(true);
+  return children?.[0];
+};
+
 export const describeAnyLoader = ({ Component, expectComponent }) => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -25,11 +37,9 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
     );
     const loading = component.toJSON();
     expect(loading.length).toBe(3);
-    expect(loading[0].props.style.display).toBe('none');
+    const img = expectWrapper(loading[0]);
     expect(loading[1].props.foo1).toBe('bar1');
     expect(loading[2].props.foo2).toBe('bar2');
-    expect(loading[0].children.length).toBe(1);
-    const img = loading[0].children[0];
     expectComponent(img, {
       src: 'http://foo.bar/image',
       alt: 'DESCRIPTION',
@@ -54,10 +64,8 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
     );
     const loading = component.toJSON();
     expect(loading.length).toBe(2);
-    expect(loading[0].props.style.display).toBe('none');
+    const img = expectWrapper(loading[0]);
     expect(loading[1].props.foo1).toBe('bar1');
-    expect(loading[0].children.length).toBe(1);
-    const img = loading[0].children[0];
     expectComponent(img, {
       src: 'http://foo.bar/image',
       alt: 'DESCRIPTION',
@@ -88,10 +96,10 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const placeholder = component.toJSON();
       expect(placeholder.length).toBe(3);
-      expect(placeholder[0].props.style.display).toBe('none');
+      const img = expectWrapper(placeholder[0]);
       expect(placeholder[1].props.foo1).toBe('bar1');
       expect(placeholder[2].props.foo2).toBe('bar2');
-      expect(placeholder[0].children).toBe(null);
+      expect(img).toBe(undefined);
     };
 
     test('null string', () => {
@@ -116,9 +124,8 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       <Component src="http://foo.bar/image" alt="DESCRIPTION"></Component>,
     );
     const loading = component.toJSON();
-    expect(loading.props.style.display).toBe('none');
+    const img = expectWrapper(loading);
     expect(loading.children.length).toBe(1);
-    const img = loading.children[0];
     expectComponent(img, {
       src: 'http://foo.bar/image',
       alt: 'DESCRIPTION',
@@ -149,10 +156,10 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const placeholder = component.toJSON();
       expect(placeholder.length).toBe(3);
-      expect(placeholder[0].props.style.display).toBe('none');
+      const img0 = expectWrapper(placeholder[0]);
       expect(placeholder[1].props.foo1).toBe('bar1');
       expect(placeholder[2].props.foo2).toBe('bar2');
-      expect(placeholder[0].children).toBe(null);
+      expect(img0).toBe(undefined);
       act(() => {
         component.update(
           <Component
@@ -169,11 +176,9 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       });
       const loading = component.toJSON();
       expect(loading.length).toBe(3);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].props.foo1).toBe('bar1');
       expect(loading[2].props.foo2).toBe('bar2');
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expect(img.props.src).toBe('http://foo.bar/image');
       expect(img.props.alt).toBe('DESCRIPTION');
       expect('children' in img.props).toBe(false);
@@ -203,11 +208,9 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(3);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].props.foo1).toBe('bar1');
       expect(loading[2].props.foo2).toBe('bar2');
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expect(img.type).toBe('img');
       expect(img.props.src).toBe('http://foo.bar/image1');
       expect(img.props.alt).toBe('DESCRIPTION1');
@@ -237,12 +240,10 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       });
       const updating = component.toJSON();
       expect(updating.length).toBe(2);
-      expect(updating[0].props.style.display).toBe('none');
+      const img2 = expectWrapper(updating[0]);
       expect(updating[1].type).toBe('img');
       expect(updating[1].props.src).toBe('http://foo.bar/image1');
       expect(updating[1].props.alt).toBe('DESCRIPTION1');
-      expect(updating[0].children.length).toBe(1);
-      const img2 = updating[0].children[0];
       expect(img2.props.src).toBe('http://foo.bar/image2');
       expect(img2.props.alt).toBe('DESCRIPTION2');
       expect('children' in img2.props).toBe(false);
@@ -274,10 +275,10 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const placeholder = component.toJSON();
       expect(placeholder.length).toBe(3);
-      expect(placeholder[0].props.style.display).toBe('none');
+      const img = expectWrapper(placeholder[0]);
       expect(placeholder[1].props.foo1).toBe('bar1');
       expect(placeholder[2].props.foo2).toBe('bar2');
-      expect(placeholder[0].children).toBe(null);
+      expect(img).toBe(undefined);
       act(() => {
         component.update(
           <Component
@@ -294,10 +295,10 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       });
       const placeholder2 = component.toJSON();
       expect(placeholder2.length).toBe(3);
-      expect(placeholder2[0].props.style.display).toBe('none');
+      const img2 = expectWrapper(placeholder2[0]);
       expect(placeholder2[1].props.foo1).toBe('bar1');
       expect(placeholder2[2].props.foo2).toBe('bar2');
-      expect(placeholder2[0].children).toBe(null);
+      expect(img2).toBe(undefined);
     });
 
     test('from other src', () => {
@@ -315,11 +316,9 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(3);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].props.foo1).toBe('bar1');
       expect(loading[2].props.foo2).toBe('bar2');
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expect(img.type).toBe('img');
       expect(img.props.src).toBe('http://foo.bar/image1');
       expect(img.props.alt).toBe('DESCRIPTION1');
@@ -371,10 +370,10 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const placeholder = component.toJSON();
       expect(placeholder.length).toBe(3);
-      expect(placeholder[0].props.style.display).toBe('none');
+      const img = expectWrapper(placeholder[0]);
       expect(placeholder[1].props.foo1).toBe('bar1');
       expect(placeholder[2].props.foo2).toBe('bar2');
-      expect(placeholder[0].children).toBe(null);
+      expect(img).toBe(undefined);
       act(() => {
         component.update(
           <Component
@@ -391,10 +390,10 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       });
       const placeholder2 = component.toJSON();
       expect(placeholder2.length).toBe(3);
-      expect(placeholder2[0].props.style.display).toBe('none');
+      const img2 = expectWrapper(placeholder2[0]);
       expect(placeholder2[1].props.foo3).toBe('bar3');
       expect(placeholder2[2].props.foo4).toBe('bar4');
-      expect(placeholder2[0].children).toBe(null);
+      expect(img2).toBe(undefined);
     });
 
     test('from other src, no change', () => {
@@ -412,11 +411,9 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(3);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].props.foo1).toBe('bar1');
       expect(loading[2].props.foo2).toBe('bar2');
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expect(img.type).toBe('img');
       expect(img.props.src).toBe('http://foo.bar/image');
       expect(img.props.alt).toBe('DESCRIPTION');
@@ -484,11 +481,9 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(2);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].type).toBe('div');
       expect(loading[1].props.blurhashRef).toBe(mockBlurhashRef);
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expectComponent(img, {
         src: 'http://foo.bar/image',
         alt: 'DESCRIPTION',
@@ -533,11 +528,9 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(2);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].type).toBe('div');
       expect(loading[1].props.blurhashRef).toBe(mockBlurhashRef);
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expectComponent(img, {
         src: 'http://foo.bar/image',
         alt: 'DESCRIPTION',
@@ -574,11 +567,9 @@ export const describeAnyLoader = ({ Component, expectComponent }) => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(2);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].type).toBe('div');
       expect(loading[1].props.blurhashRef).toBe(mockBlurhashRef);
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expectComponent(img, {
         src: 'http://foo.bar/image',
         alt: 'DESCRIPTION',

--- a/src/components/ImageLoader/ImageLoader.test.jsx
+++ b/src/components/ImageLoader/ImageLoader.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { create, act } from 'react-test-renderer';
 import ImageLoader from './ImageLoader';
-import { describeAnyLoader } from './AnyLoader.test';
+import { describeAnyLoader, expectWrapper } from './AnyLoader.test';
 
 describe('ImageLoader', () => {
   describeAnyLoader({
@@ -42,11 +42,9 @@ describe('ImageLoader', () => {
     );
     const loading = component.toJSON();
     expect(loading.length).toBe(3);
-    expect(loading[0].props.style.display).toBe('none');
+    const img = expectWrapper(loading[0]);
     expect(loading[1].props.foo1).toBe('bar1');
     expect(loading[2].props.foo2).toBe('bar2');
-    expect(loading[0].children.length).toBe(1);
-    const img = loading[0].children[0];
     expectComponent(img, {
       src: 'http://foo.bar/image',
       alt: 'DESCRIPTION',
@@ -87,11 +85,9 @@ describe('ImageLoader', () => {
     );
     const loading = component.toJSON();
     expect(loading.length).toBe(3);
-    expect(loading[0].props.style.display).toBe('none');
+    const img = expectWrapper(loading[0]);
     expect(loading[1].props.foo1).toBe('bar1');
     expect(loading[2].props.foo2).toBe('bar2');
-    expect(loading[0].children.length).toBe(1);
-    const img = loading[0].children[0];
     expectComponent(img, {
       src: 'http://foo.bar/image1',
       alt: 'DESCRIPTION1',
@@ -127,7 +123,7 @@ describe('ImageLoader', () => {
     });
     const updating = component.toJSON();
     expect(updating.length).toBe(2);
-    expect(updating[0].props.style.display).toBe('none');
+    const img2 = expectWrapper(updating[0]);
     const placeholderImg = updating[1];
     expectComponent(placeholderImg, {
       src: 'http://foo.bar/image1',
@@ -137,7 +133,6 @@ describe('ImageLoader', () => {
     expect(childrenP.length).toBe(2);
     expect(childrenP[0].props.foo3).toBe('bar3');
     expect(childrenP[1].props.foo4).toBe('bar4');
-    const img2 = updating[0].children[0];
     expectComponent(img2, {
       src: 'http://foo.bar/image2',
       alt: 'DESCRIPTION2',

--- a/src/components/ImageLoader/Img.test.jsx
+++ b/src/components/ImageLoader/Img.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { create, act } from 'react-test-renderer';
 import Img from './Img';
-import { describeAnyLoader } from './AnyLoader.test';
+import { describeAnyLoader, expectWrapper } from './AnyLoader.test';
 import config from '@plone/volto/registry';
 import makeSrcSet from './makeSrcSet';
 
@@ -72,11 +72,9 @@ describe('Img', () => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(3);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].props.foo1).toBe('bar1');
       expect(loading[2].props.foo2).toBe('bar2');
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expectComponent(img, {
         src: 'http://foo.bar/image',
         alt: 'DESCRIPTION',
@@ -115,11 +113,9 @@ describe('Img', () => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(3);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].props.foo1).toBe('bar1');
       expect(loading[2].props.foo2).toBe('bar2');
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expectComponent(img, {
         src: 'http://foo.bar/image',
         alt: 'DESCRIPTION',
@@ -153,11 +149,9 @@ describe('Img', () => {
       );
       const loading = component.toJSON();
       expect(loading.length).toBe(3);
-      expect(loading[0].props.style.display).toBe('none');
+      const img = expectWrapper(loading[0]);
       expect(loading[1].props.foo1).toBe('bar1');
       expect(loading[2].props.foo2).toBe('bar2');
-      expect(loading[0].children.length).toBe(1);
-      const img = loading[0].children[0];
       expectComponent(img, {
         src: 'http://foo.bar/image',
         alt: 'DESCRIPTION',

--- a/src/components/ImageLoader/makeBlurhash.jsx
+++ b/src/components/ImageLoader/makeBlurhash.jsx
@@ -24,11 +24,6 @@ const makeBlurhash = (options, blurhashRef) => {
       const { resolutionX, resolutionY, punch, style } = this.options;
       const result = {};
       if (blurhash) {
-        if (placeholder) {
-          throw new Error(
-            'blurhash and placeholder properties cannot both be specified',
-          );
-        }
         // Note the hash itself may contain the delimiter
         const delimiter = blurhash.indexOf(':');
         const ratio = parseFloat(blurhash.substring(0, delimiter));

--- a/src/components/ImageLoader/makeBlurhash.test.jsx
+++ b/src/components/ImageLoader/makeBlurhash.test.jsx
@@ -50,14 +50,21 @@ describe('makeBlurhash', () => {
       expect(result.hasOwnProperty('blurhash')).toBe(false);
       expect(result.hasOwnProperty('placeholder')).toBe(false);
     });
-    test('placeholder override throws error', () => {
-      const o = makeBlurhash();
-      expect(() =>
-        o.fromProps({
-          blurhash: '1:BLURHASH',
-          placeholder: <img alt="ALT" />,
-        }),
-      ).toThrow('blurhash and placeholder properties cannot both be specified');
+    test('blurhash overrides placeholder', () => {
+      const result = makeBlurhash().fromProps({
+        blurhash: '1:BLURHASH',
+        placeholder: <img alt="ALT" />,
+      });
+      expect(result.hasOwnProperty('blurhash')).toBe(true);
+      expect(result.blurhash).toBe(undefined);
+      expectProps(result.placeholder, 'div', {
+        hash: 'BLURHASH',
+        ratio: 1,
+        punch: 1,
+        width: 32,
+        height: 32,
+        style: {},
+      });
     });
   });
 


### PR DESCRIPTION
- Support lazy loading in the imageloader

  This makes loading="lazy" work. Previously, lazy loading images were never loaded.

- Allow blurhash prop to override placeholder prop in the imageloader

  Both properties can now be specified, previously it resulted in an
  exception.