### PR TITLE
Fix export of hrefList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix export of hrefList with href that is not a string @davisagli
+
 ### Internal
 
 ## 12.2.2 (2022-09-01)

--- a/src/server.js
+++ b/src/server.js
@@ -44,16 +44,6 @@ function jsonExporter(req, res, next) {
     })
     .then((content) => {
       return run(
-        `. | .blocks[].hrefList[]?.href |= sub("${config.settings.apiPath}";"")`,
-        content,
-        {
-          input: 'json',
-          output: 'json',
-        },
-      );
-    })
-    .then((content) => {
-      return run(
         `(.. | .href? | strings) |= sub("${config.settings.apiPath}";"")`,
         content,
         {


### PR DESCRIPTION
One of those fun bugs where you only have to remove code to fix it. The `href` in items of an hrefList is still be handled by the rules below that match `href` anywhere as either a string or an array of objects.