### PR TITLE
Fix image loading without placeholder or blurhash, fixes jump (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix image loading without placeholder or blurhash, fixes jump #276 @reebalazs
+
 ### Internal
 
 - Fix tests after blurhash loading fixes #276 @reebalazs

--- a/src/components/ImageLoader/AnyLoader.jsx
+++ b/src/components/ImageLoader/AnyLoader.jsx
@@ -49,17 +49,26 @@ export default (props) => {
     }
   }, [isLoaded, imgProps.src, placeholderProps.src, isComplete, onLoad]);
   useEffect(() => {
-    const placeholderCurrent = placeholder?.props.blurhashRef?.current;
-    if (placeholderCurrent) {
+    // copy the aspect ratio, if we have it, to the extra style reference
+    // to allow the BlurhashCanvas to check if there is a fixed aspect ratio
+    const placeholderExtraStyleRefCurrent =
+      placeholder?.props.placeholderExtraStyleRef?.current;
+    if (ref.current && placeholderExtraStyleRefCurrent) {
       const computedStyle = getComputedStyle(ref.current);
       const { aspectRatio, objectFit } = computedStyle;
-      if (aspectRatio !== 'auto' && !placeholderCurrent.style.aspectRatio) {
-        placeholderCurrent.style.aspectRatio = aspectRatio;
-        placeholderCurrent.style.objectFit = objectFit;
+      if (
+        aspectRatio !== 'auto' &&
+        !placeholderExtraStyleRefCurrent.aspectRatio
+      ) {
+        placeholderExtraStyleRefCurrent.aspectRatio = aspectRatio;
+        placeholderExtraStyleRefCurrent.objectFit = objectFit;
       }
     }
   });
-  return (
+  // If there is no placeholder (or any transformer generating it, such as blurhash)
+  // then shortcut to show the image without loading.
+  // Else set up the loader.
+  return placeholder ? (
     <>
       {isLoaded ? (
         createComponent(imgProps, children)
@@ -78,5 +87,7 @@ export default (props) => {
         ? createComponent(placeholderProps, placeholderChildren)
         : placeholder}
     </>
-  );
+  ) : imgProps.src ? (
+    createComponent(imgProps, children)
+  ) : null;
 };

--- a/src/components/ImageLoader/BlurhashCanvas.jsx
+++ b/src/components/ImageLoader/BlurhashCanvas.jsx
@@ -12,15 +12,15 @@ export default ({
   height,
   imgClass,
   imgStyle,
-  blurhashRef,
+  imgWidth,
+  imgHeight,
+  placeholderExtraStyleRef,
 }) => {
-  if (!blurhashRef) {
-    blurhashRef = useRef();
-  }
+  const ref = useRef();
   const [styleHeight, setStyleHeight] = useState();
 
   useEffect(() => {
-    const canvas = blurhashRef.current;
+    const canvas = ref.current;
     if (canvas && styleHeight) {
       const pixels = decode(hash, width, height, punch);
       const ctx = canvas.getContext('2d');
@@ -28,13 +28,14 @@ export default ({
       imageData.data.set(pixels);
       ctx.putImageData(imageData, 0, 0);
     }
-  }, [hash, width, height, punch, blurhashRef, styleHeight]);
+  }, [hash, width, height, punch, styleHeight]);
 
-  const aspectRatio = blurhashRef.current?.style.aspectRatio;
+  //  const aspectRatio = blurhashRef.current?.style.aspectRatio;
+  const aspectRatio = placeholderExtraStyleRef?.current?.aspectRatio;
   useEffect(() => {
-    const canvas = blurhashRef.current;
+    const canvas = ref.current;
     if (canvas) {
-      if (canvas?.style.aspectRatio) {
+      if (placeholderExtraStyleRef?.current?.aspectRatio) {
         setStyleHeight('auto');
       } else {
         const adjustHeight = () => setStyleHeight(canvas.offsetWidth / ratio);
@@ -44,7 +45,7 @@ export default ({
         return () => observer.unobserve(canvas);
       }
     }
-  }, [ratio, blurhashRef, aspectRatio]);
+  }, [ratio, aspectRatio, placeholderExtraStyleRef]);
 
   // We only create a canvas after we have processed the original image's
   // computed style. Until then, we render a blank image to make sure
@@ -52,17 +53,23 @@ export default ({
   // image lets us mimic the original image's computed css style.
   return styleHeight ? (
     <canvas
-      style={{ ...style, height: styleHeight }}
+      style={{
+        ...style,
+        ...placeholderExtraStyleRef?.current,
+        height: styleHeight,
+      }}
       height={height}
       width={width}
-      ref={blurhashRef}
+      ref={ref}
     />
   ) : (
     <img
       src={BLANK}
       alt=""
       className={imgClass ? imgClass + ' blurhash' : 'blurhash'}
-      style={imgStyle}
+      style={{ ...imgStyle, ...placeholderExtraStyleRef?.current }}
+      width={imgWidth}
+      height={imgHeight}
       data={JSON.stringify({
         hash,
         punch,
@@ -71,7 +78,7 @@ export default ({
         height,
         canvasStyle: style,
       })}
-      ref={blurhashRef}
+      ref={ref}
     />
   );
 };

--- a/src/components/ImageLoader/BlurhashCanvas.test.jsx
+++ b/src/components/ImageLoader/BlurhashCanvas.test.jsx
@@ -70,7 +70,7 @@ describe('BlurhashCanvas', () => {
         expect(props.data).toEqual(
           '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":24}',
         );
-        expect(props.style).toBe(undefined);
+        expect(props.style).toEqual({});
       });
 
       test('with imgClass, imgStyle', () => {
@@ -103,6 +103,36 @@ describe('BlurhashCanvas', () => {
           '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":24}',
         );
       });
+    });
+
+    test('with imgWidth, imgHeight', () => {
+      let component;
+      mockDecodeResult = 'PIXELS';
+      act(() => {
+        component = create(
+          <BlurhashCanvas
+            hash="HASH"
+            ratio={2}
+            punch={1}
+            width={32}
+            height={24}
+            imgWidth="1440"
+            imgHeight="810"
+          />,
+          // There is no ref on the server.
+        );
+      });
+      const img = component.toJSON();
+      expect(img.type).toBe('img');
+      expect(img.children).toBe(null);
+      const props = img.props;
+      expect(typeof props.src).toBe('string');
+      expect(props.alt).toBe('');
+      expect(props.width).toBe('1440');
+      expect(props.height).toBe('810');
+      expect(props.data).toEqual(
+        '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":24}',
+      );
     });
 
     describe('renders as canvas', () => {
@@ -251,10 +281,10 @@ describe('BlurhashCanvas', () => {
       expect(mockContext.putImageData).toBeCalledWith(mockImageData, 0, 0);
     });
 
-    test('accepts blurhashRef', () => {
+    test('accepts placeholderExtraStyleRef', () => {
       let component;
       mockDecodeResult = 'PIXELS';
-      const mockBlurhashRef = { current: null };
+      const mockPlaceholderExtraStyleRef = { current: {} };
       act(() => {
         component = create(
           <BlurhashCanvas
@@ -263,7 +293,7 @@ describe('BlurhashCanvas', () => {
             punch={1}
             width={32}
             height={24}
-            blurhashRef={mockBlurhashRef}
+            placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           {
             createNodeMock: (el) => mockCanvas,
@@ -276,7 +306,8 @@ describe('BlurhashCanvas', () => {
       const props = canvas.props;
       expect(props.height).toBe(24);
       expect(props.width).toBe(32);
-      expect(mockBlurhashRef.current).toBe(mockCanvas);
+      // Nothing to check here.
+      expect(mockPlaceholderExtraStyleRef.current).toEqual({});
     });
   });
 
@@ -284,6 +315,7 @@ describe('BlurhashCanvas', () => {
     test('initially', () => {
       let component;
       mockCanvas.offsetWidth = 100;
+      const mockPlaceholderExtraStyleRef = { current: {} };
       act(() => {
         component = create(
           <BlurhashCanvas
@@ -292,6 +324,7 @@ describe('BlurhashCanvas', () => {
             punch={1}
             width={32}
             height={24}
+            placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           { createNodeMock: () => mockCanvas },
         );
@@ -305,6 +338,7 @@ describe('BlurhashCanvas', () => {
     test('updates', () => {
       let component;
       mockCanvas.offsetWidth = 100;
+      const mockPlaceholderExtraStyleRef = { current: {} };
       act(() => {
         component = create(
           <BlurhashCanvas
@@ -313,6 +347,7 @@ describe('BlurhashCanvas', () => {
             punch={1}
             width={32}
             height={24}
+            placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           { createNodeMock: () => mockCanvas },
         );
@@ -332,7 +367,9 @@ describe('BlurhashCanvas', () => {
     test('initially', () => {
       let component;
       mockCanvas.offsetWidth = 100;
-      mockCanvas.style.aspectRatio = '2 / 1';
+      const mockPlaceholderExtraStyleRef = {
+        current: { aspectRatio: '2 / 1' },
+      };
       act(() => {
         component = create(
           <BlurhashCanvas
@@ -341,6 +378,7 @@ describe('BlurhashCanvas', () => {
             punch={1}
             width={32}
             height={24}
+            placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           { createNodeMock: () => mockCanvas },
         );
@@ -354,6 +392,9 @@ describe('BlurhashCanvas', () => {
     test('updates', () => {
       let component;
       mockCanvas.offsetWidth = 100;
+      const mockPlaceholderExtraStyleRef = {
+        current: { aspectRatio: '2 / 1' },
+      };
       act(() => {
         component = create(
           <BlurhashCanvas
@@ -362,6 +403,7 @@ describe('BlurhashCanvas', () => {
             punch={1}
             width={32}
             height={24}
+            placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           { createNodeMock: () => mockCanvas },
         );

--- a/src/components/ImageLoader/ImageLoader.test.jsx
+++ b/src/components/ImageLoader/ImageLoader.test.jsx
@@ -14,6 +14,9 @@ describe('ImageLoader', () => {
       expect('children' in img.props).toBe(false);
       expect(img.children).toBe(null);
     },
+    // Skip tests that only make sense with a component
+    // that reacts on the extra placeholder styles
+    runPlaceholderExtraStyleTests: false,
   });
 
   const expectComponent = (img, props) => {

--- a/src/components/ImageLoader/Img.jsx
+++ b/src/components/ImageLoader/Img.jsx
@@ -353,10 +353,10 @@ Further generalization on the resizing strategy would be possible, once the need
  */
 
 export default ({ blurhashOptions, ...props }) => {
-  const blurhashRef = useRef();
+  const placeholderExtraStyleRef = useRef({});
   props = extendProps(
     props,
-    makeBlurhash(blurhashOptions, blurhashRef).fromProps(props),
+    makeBlurhash(blurhashOptions, placeholderExtraStyleRef).fromProps(props),
   );
   return AnyLoader({
     ...props,

--- a/src/components/ImageLoader/makeBlurhash.jsx
+++ b/src/components/ImageLoader/makeBlurhash.jsx
@@ -1,7 +1,7 @@
 import BlurhashCanvas from './BlurhashCanvas';
 const config = require('@plone/volto/registry').default;
 
-const makeBlurhash = (options, blurhashRef) => {
+const makeBlurhash = (options, placeholderExtraStyleRef) => {
   if (options && options.hasOwnProperty('fromProps')) {
     // If already a cooked object - just use it.
     options = options.options;
@@ -20,7 +20,7 @@ const makeBlurhash = (options, blurhashRef) => {
   }
   return {
     options,
-    fromProps({ placeholder, blurhash, className, style }) {
+    fromProps({ placeholder, blurhash, className, style, width, height }) {
       const {
         resolutionX,
         resolutionY,
@@ -37,8 +37,10 @@ const makeBlurhash = (options, blurhashRef) => {
           <BlurhashCanvas
             imgClass={className}
             imgStyle={style}
+            imgWidth={width}
+            imgHeight={height}
             style={canvasStyle}
-            blurhashRef={blurhashRef}
+            placeholderExtraStyleRef={placeholderExtraStyleRef}
             hash={hash}
             ratio={ratio}
             punch={punch}

--- a/src/components/ImageLoader/makeBlurhash.test.jsx
+++ b/src/components/ImageLoader/makeBlurhash.test.jsx
@@ -90,6 +90,26 @@ describe('makeBlurhash', () => {
     });
   });
 
+  test('with props width, height', () => {
+    const result = makeBlurhash().fromProps({
+      blurhash: '1:BLURHASH',
+      width: '1440',
+      height: '810',
+    });
+    expectProps(result.placeholder, 'div', {
+      hash: 'BLURHASH',
+      ratio: 1,
+      punch: 1,
+      width: 32,
+      height: 32,
+      style: {},
+      imgWidth: '1440',
+      imgHeight: '810',
+    });
+    expect(result.hasOwnProperty('blurhash')).toBe(true);
+    expect(result.blurhash).toBe(undefined);
+  });
+
   describe('options', () => {
     test('resolutionX', () => {
       const result = makeBlurhash({ resolutionX: 64 }).fromProps({
@@ -155,10 +175,10 @@ describe('makeBlurhash', () => {
     });
   });
 
-  describe('blurhashRef', () => {
+  describe('placeholderExtraStyleRef', () => {
     test('passed to component', () => {
-      const mockBlurhashRef = { current: null };
-      const result = makeBlurhash({}, mockBlurhashRef).fromProps({
+      const mockPlaceholderExtraStyleRef = { current: null };
+      const result = makeBlurhash({}, mockPlaceholderExtraStyleRef).fromProps({
         blurhash: '1:BLURHASH',
       });
       expectProps(result.placeholder, 'div', {
@@ -168,9 +188,11 @@ describe('makeBlurhash', () => {
         width: 32,
         height: 32,
         style: {},
-        blurhashRef: mockBlurhashRef,
+        placeholderExtraStyleRef: mockPlaceholderExtraStyleRef,
       });
-      expect(result.placeholder.props.blurhashRef).toBe(mockBlurhashRef);
+      expect(result.placeholder.props.placeholderExtraStyleRef).toBe(
+        mockPlaceholderExtraStyleRef,
+      );
       expect(result.hasOwnProperty('blurhash')).toBe(true);
       expect(result.blurhash).toBe(undefined);
     });


### PR DESCRIPTION
Fix edge case when there is no placeholder (or blurhash). In this case shortcut to show the image component directly without any loading.

This fixes a "jump" during image loading for components that don't define a blurhash (and neither a placeholder).