### PR TITLE
Image loader: fix setting height ignored in some cases, fixes jump #276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Image loader: fix setting height ignored in some cases, fixes jump #276 @reebalazs
+
 ### Internal
 
 ## 12.3.2 (2022-09-09)

--- a/src/components/ImageLoader/AnyLoader.jsx
+++ b/src/components/ImageLoader/AnyLoader.jsx
@@ -56,8 +56,10 @@ export default (props) => {
     if (ref.current && placeholderExtraStyleRefCurrent) {
       const computedStyle = getComputedStyle(ref.current);
       const { aspectRatio, objectFit } = computedStyle;
+      // Important: ignore auto aspect ratios from the image,
+      // ie. "auto 1440 / 980"
       if (
-        aspectRatio !== 'auto' &&
+        !aspectRatio?.startsWith('auto') &&
         !placeholderExtraStyleRefCurrent.aspectRatio
       ) {
         placeholderExtraStyleRefCurrent.aspectRatio = aspectRatio;


### PR DESCRIPTION
Aspect ratio can also be "auto" when it's a computed style on the image and starts with auto, following the ratio. Fix condition to acknowledge this.

This fixes a "jumping" problem during loading for images that do not have an aspect ratio set.