### PR TITLE
Image loader: fix blurhash canvas aspect ratio #276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Image loader: fix blurhash canvas aspect ratio #276 @reebalazs
+
 ### Internal
 
 ## 12.3.3 (2022-09-14)

--- a/src/components/ImageLoader/BlurhashCanvas.jsx
+++ b/src/components/ImageLoader/BlurhashCanvas.jsx
@@ -9,7 +9,6 @@ export default ({
   punch,
   ratio,
   width,
-  height,
   imgClass,
   imgStyle,
   imgWidth,
@@ -18,6 +17,8 @@ export default ({
 }) => {
   const ref = useRef();
   const [styleHeight, setStyleHeight] = useState();
+  // Canvas height is determined from the width (resolutionX) and ratio
+  const height = Math.ceil(width / ratio);
 
   useEffect(() => {
     const canvas = ref.current;

--- a/src/components/ImageLoader/BlurhashCanvas.test.jsx
+++ b/src/components/ImageLoader/BlurhashCanvas.test.jsx
@@ -7,7 +7,7 @@ let mockDecodeResult;
 jest.mock('blurhash', () => {
   return {
     __esModule: true,
-    decode: jest.fn((hash, width, height, punch) => mockDecodeResult),
+    decode: jest.fn((hash, width, punch) => mockDecodeResult),
   };
 });
 
@@ -49,13 +49,7 @@ describe('BlurhashCanvas', () => {
         mockDecodeResult = 'PIXELS';
         act(() => {
           component = create(
-            <BlurhashCanvas
-              hash="HASH"
-              ratio={2}
-              punch={1}
-              width={32}
-              height={24}
-            />,
+            <BlurhashCanvas hash="HASH" ratio={2} punch={1} width={32} />,
             // There is no ref on the server.
           );
         });
@@ -68,7 +62,7 @@ describe('BlurhashCanvas', () => {
         // important marker used by fast-blurhash.js
         expect(props.className).toBe('blurhash');
         expect(props.data).toEqual(
-          '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":24}',
+          '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":16}',
         );
         expect(props.style).toEqual({});
       });
@@ -83,7 +77,6 @@ describe('BlurhashCanvas', () => {
               ratio={2}
               punch={1}
               width={32}
-              height={24}
               imgClass="IMG-CLASS"
               imgStyle={{ width: '100%' }}
             />,
@@ -100,7 +93,7 @@ describe('BlurhashCanvas', () => {
         expect(props.className).toBe('IMG-CLASS blurhash');
         expect(props.style).toEqual({ width: '100%' });
         expect(props.data).toEqual(
-          '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":24}',
+          '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":16}',
         );
       });
     });
@@ -115,7 +108,6 @@ describe('BlurhashCanvas', () => {
             ratio={2}
             punch={1}
             width={32}
-            height={24}
             imgWidth="1440"
             imgHeight="810"
           />,
@@ -131,7 +123,7 @@ describe('BlurhashCanvas', () => {
       expect(props.width).toBe('1440');
       expect(props.height).toBe('810');
       expect(props.data).toEqual(
-        '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":24}',
+        '{"hash":"HASH","punch":1,"ratio":2,"width":32,"height":16}',
       );
     });
 
@@ -142,13 +134,7 @@ describe('BlurhashCanvas', () => {
         mockCanvas.offsetWidth = 100;
         act(() => {
           component = create(
-            <BlurhashCanvas
-              hash="HASH"
-              ratio={2}
-              punch={1}
-              width={32}
-              height={24}
-            />,
+            <BlurhashCanvas hash="HASH" ratio={2} punch={1} width={32} />,
             // The appearance of the ref turns it into a real canvas.
             { createNodeMock: () => mockCanvas },
           );
@@ -157,7 +143,7 @@ describe('BlurhashCanvas', () => {
         expect(canvas.type).toBe('canvas');
         expect(canvas.children).toBe(null);
         const props = canvas.props;
-        expect(props.height).toBe(24);
+        expect(props.height).toBe(16);
         expect(props.width).toBe(32);
         expect(props.style).toEqual({ height: 50 });
       });
@@ -174,7 +160,6 @@ describe('BlurhashCanvas', () => {
             ratio={2}
             punch={1}
             width={32}
-            height={24}
             imgClass="IMG-CLASS"
             imgStyle={{ width: '100%' }}
           />,
@@ -186,7 +171,7 @@ describe('BlurhashCanvas', () => {
       expect(canvas.type).toBe('canvas');
       expect(canvas.children).toBe(null);
       const props = canvas.props;
-      expect(props.height).toBe(24);
+      expect(props.height).toBe(16);
       expect(props.width).toBe(32);
       expect(props.style).toEqual({ height: 50 });
       expect(props.className).toBe(undefined);
@@ -198,13 +183,7 @@ describe('BlurhashCanvas', () => {
     mockDecodeResult = 'PIXELS';
     act(() => {
       component = create(
-        <BlurhashCanvas
-          hash="HASH"
-          ratio={2}
-          punch={1}
-          width={32}
-          height={24}
-        />,
+        <BlurhashCanvas hash="HASH" ratio={2} punch={1} width={32} />,
       );
     });
     const canvas = component.toJSON();
@@ -225,20 +204,14 @@ describe('BlurhashCanvas', () => {
       mockDecodeResult = 'PIXELS';
       act(() => {
         component = create(
-          <BlurhashCanvas
-            hash="HASH"
-            ratio={2}
-            punch={1}
-            width={32}
-            height={24}
-          />,
+          <BlurhashCanvas hash="HASH" ratio={2} punch={1} width={32} />,
           { createNodeMock: () => mockCanvas },
         );
       });
       const canvas = component.toJSON();
       expect(canvas.type).toBe('canvas');
       expect(canvas.children).toBe(null);
-      expect(decode).toBeCalledWith('HASH', 32, 24, 1);
+      expect(decode).toBeCalledWith('HASH', 32, 16, 1);
       expect(mockImageData.data.set).toBeCalledWith('PIXELS');
       expect(mockContext.putImageData).toBeCalledWith(mockImageData, 0, 0);
     });
@@ -248,35 +221,23 @@ describe('BlurhashCanvas', () => {
       mockDecodeResult = 'PIXELS';
       act(() => {
         component = create(
-          <BlurhashCanvas
-            hash="HASH"
-            ratio={2}
-            punch={1}
-            width={32}
-            height={24}
-          />,
+          <BlurhashCanvas hash="HASH" ratio={2} punch={1} width={32} />,
           { createNodeMock: () => mockCanvas },
         );
       });
       mockDecodeResult = 'NEWPIXELS';
       act(() => {
         component.update(
-          <BlurhashCanvas
-            hash="NEWHASH"
-            ratio={2}
-            punch={1}
-            width={32}
-            height={24}
-          />,
+          <BlurhashCanvas hash="NEWHASH" ratio={2} punch={1} width={32} />,
         );
       });
       const canvas = component.toJSON();
       expect(canvas.type).toBe('canvas');
       expect(canvas.children).toBe(null);
       const props = canvas.props;
-      expect(props.height).toBe(24);
+      expect(props.height).toBe(16);
       expect(props.width).toBe(32);
-      expect(decode).toBeCalledWith('NEWHASH', 32, 24, 1);
+      expect(decode).toBeCalledWith('NEWHASH', 32, 16, 1);
       expect(mockImageData.data.set).toBeCalledWith('NEWPIXELS');
       expect(mockContext.putImageData).toBeCalledWith(mockImageData, 0, 0);
     });
@@ -292,7 +253,6 @@ describe('BlurhashCanvas', () => {
             ratio={2}
             punch={1}
             width={32}
-            height={24}
             placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           {
@@ -304,7 +264,7 @@ describe('BlurhashCanvas', () => {
       expect(canvas.type).toBe('canvas');
       expect(canvas.children).toBe(null);
       const props = canvas.props;
-      expect(props.height).toBe(24);
+      expect(props.height).toBe(16);
       expect(props.width).toBe(32);
       // Nothing to check here.
       expect(mockPlaceholderExtraStyleRef.current).toEqual({});
@@ -323,7 +283,6 @@ describe('BlurhashCanvas', () => {
             ratio={2}
             punch={1}
             width={32}
-            height={24}
             placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           { createNodeMock: () => mockCanvas },
@@ -346,7 +305,6 @@ describe('BlurhashCanvas', () => {
             ratio={2}
             punch={1}
             width={32}
-            height={24}
             placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           { createNodeMock: () => mockCanvas },
@@ -377,7 +335,6 @@ describe('BlurhashCanvas', () => {
             ratio={2}
             punch={1}
             width={32}
-            height={24}
             placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           { createNodeMock: () => mockCanvas },
@@ -402,7 +359,6 @@ describe('BlurhashCanvas', () => {
             ratio={2}
             punch={1}
             width={32}
-            height={24}
             placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
           />,
           { createNodeMock: () => mockCanvas },
@@ -417,6 +373,54 @@ describe('BlurhashCanvas', () => {
       expect(canvas.type).toBe('canvas');
       expect(canvas.children).toBe(null);
       expect(canvas.props.style.height).toBe('auto');
+    });
+  });
+
+  describe('sets canvas height from aspect ratio', () => {
+    test('with some ratio', () => {
+      let component;
+      mockCanvas.offsetWidth = 100;
+      const mockPlaceholderExtraStyleRef = { current: {} };
+      act(() => {
+        component = create(
+          <BlurhashCanvas
+            hash="HASH"
+            ratio={0.5}
+            punch={1}
+            width={32}
+            placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
+          />,
+          { createNodeMock: () => mockCanvas },
+        );
+      });
+      const canvas = component.toJSON();
+      expect(canvas.type).toBe('canvas');
+      expect(canvas.children).toBe(null);
+      expect(canvas.props.height).toBe(64);
+      expect(canvas.props.width).toBe(32);
+    });
+
+    test('with some other ratio', () => {
+      let component;
+      mockCanvas.offsetWidth = 100;
+      const mockPlaceholderExtraStyleRef = { current: {} };
+      act(() => {
+        component = create(
+          <BlurhashCanvas
+            hash="HASH"
+            ratio={4}
+            punch={1}
+            width={32}
+            placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
+          />,
+          { createNodeMock: () => mockCanvas },
+        );
+      });
+      const canvas = component.toJSON();
+      expect(canvas.type).toBe('canvas');
+      expect(canvas.children).toBe(null);
+      expect(canvas.props.height).toBe(8);
+      expect(canvas.props.width).toBe(32);
     });
   });
 });

--- a/src/components/ImageLoader/Img.jsx
+++ b/src/components/ImageLoader/Img.jsx
@@ -275,12 +275,7 @@ Example for Volto icon:
 It is an object containing the options to control the blurhash generation.
 
 `resolutionX`: the canvas width resolution, by default 32. Increasing this value will
-create larger blurhash. Used for decoding the blurhash.
-
-`resolutionY`: the canvas height resolution, by default 32. Increasing this value will
-create larger blurhash. The width and the height does not have to refer to the actual
-image ratio that can be anything and the canvas will be stretched as needed.
-Used for decoding the blurhash.
+create larger blurhash. Used for decoding the blurhash. This value should not correspond to the actual blurhash resolution but it should be a large enough value to accomodate it. Since the maximum blurhash resolution is 9, there is no point in creating a canvas larger than the default. The vertical resolution cannot be specified as it is calculated from the aspect ratio of the actual image.
 
 `punch`: the blurhash punch parameter as specified by the blurhash library documentarion,
 by default 1. A larger value will result in a larger blurhash and a more detailed blurred
@@ -296,7 +291,6 @@ Example for setting the default options in config:
 ```js
   config.settings.blurhashOptions = {
     resolutionX: 32,
-    resolutionY: 32,
     punch: 1,
     style: { width: '100%' },
   };

--- a/src/components/ImageLoader/makeBlurhash.jsx
+++ b/src/components/ImageLoader/makeBlurhash.jsx
@@ -10,7 +10,6 @@ const makeBlurhash = (options, placeholderExtraStyleRef) => {
     options = Object.assign(
       {
         resolutionX: 32,
-        resolutionY: 32,
         punch: 1,
         style: {},
       },
@@ -21,12 +20,7 @@ const makeBlurhash = (options, placeholderExtraStyleRef) => {
   return {
     options,
     fromProps({ placeholder, blurhash, className, style, width, height }) {
-      const {
-        resolutionX,
-        resolutionY,
-        punch,
-        style: canvasStyle,
-      } = this.options;
+      const { resolutionX, punch, style: canvasStyle } = this.options;
       const result = {};
       if (blurhash) {
         // Note the hash itself may contain the delimiter
@@ -45,7 +39,6 @@ const makeBlurhash = (options, placeholderExtraStyleRef) => {
             ratio={ratio}
             punch={punch}
             width={resolutionX}
-            height={resolutionY}
           />
         );
         result.blurhash = undefined;

--- a/src/components/ImageLoader/makeBlurhash.test.jsx
+++ b/src/components/ImageLoader/makeBlurhash.test.jsx
@@ -37,7 +37,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 32,
-        height: 32,
         style: {},
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -62,7 +61,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 32,
-        height: 32,
         style: {},
       });
     });
@@ -78,7 +76,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 32,
-        height: 32,
         style: {},
         imgClass: 'CLASSNAME',
         imgStyle: {
@@ -101,7 +98,6 @@ describe('makeBlurhash', () => {
       ratio: 1,
       punch: 1,
       width: 32,
-      height: 32,
       style: {},
       imgWidth: '1440',
       imgHeight: '810',
@@ -120,22 +116,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 64,
-        height: 32,
-        style: {},
-      });
-      expect(result.hasOwnProperty('blurhash')).toBe(true);
-      expect(result.blurhash).toBe(undefined);
-    });
-    test('resolutionY', () => {
-      const result = makeBlurhash({ resolutionY: 64 }).fromProps({
-        blurhash: '1:BLURHASH',
-      });
-      expectProps(result.placeholder, 'div', {
-        hash: 'BLURHASH',
-        ratio: 1,
-        punch: 1,
-        width: 32,
-        height: 64,
         style: {},
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -150,7 +130,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 4,
         width: 32,
-        height: 32,
         style: {},
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -167,7 +146,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 32,
-        height: 32,
         style: { width: '100%', color: 'blue' },
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -186,7 +164,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 32,
-        height: 32,
         style: {},
         placeholderExtraStyleRef: mockPlaceholderExtraStyleRef,
       });
@@ -206,7 +183,6 @@ describe('makeBlurhash', () => {
         ratio: 2,
         punch: 1,
         width: 32,
-        height: 32,
         style: {},
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -219,7 +195,6 @@ describe('makeBlurhash', () => {
         ratio: 0.5,
         punch: 1,
         width: 32,
-        height: 32,
         style: {},
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -232,7 +207,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 32,
-        height: 32,
         style: {},
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -251,23 +225,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 64,
-        height: 32,
-        style: {},
-      });
-      expect(result.hasOwnProperty('blurhash')).toBe(true);
-      expect(result.blurhash).toBe(undefined);
-    });
-    test('resolutionY', () => {
-      Object.assign(options, { resolutionY: 64 });
-      const result = makeBlurhash().fromProps({
-        blurhash: '1:BLURHASH',
-      });
-      expectProps(result.placeholder, 'div', {
-        hash: 'BLURHASH',
-        ratio: 1,
-        punch: 1,
-        width: 32,
-        height: 64,
         style: {},
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -283,7 +240,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 4,
         width: 32,
-        height: 32,
         style: {},
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);
@@ -299,7 +255,6 @@ describe('makeBlurhash', () => {
         ratio: 1,
         punch: 1,
         width: 32,
-        height: 32,
         style: { width: '100%', color: 'blue' },
       });
       expect(result.hasOwnProperty('blurhash')).toBe(true);


### PR DESCRIPTION
This problem is apparent with `aspect-ratio: cover`, while it was also present with `aspect-ratio: fill`, it's not easily observable. The solution is to make the blurhash canvas have the same aspect ratio as the *original* image (not the rendered styles), this way aspect-ratio will work identically to the to-be-loaded image.

Also deprecate prop `resolutionY` which is now calculated from the ratio.