### PR TITLE
Fix image loading error if the error is already completed (#825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix image loading error if the error is already completed (#825) @reebalazs
+
 ### Internal
 
 - Update to use latest `@plone/scripts` @sneridagh

--- a/src/components/ImageLoader/AnyLoader.jsx
+++ b/src/components/ImageLoader/AnyLoader.jsx
@@ -39,15 +39,23 @@ export default (props) => {
     setPlaceholderProps(imgProps);
     setPlaceholderChildren(children);
   }, [imgProps, children]);
-  const isComplete = ref.current?.complete;
+  const complete = ref.current?.complete;
+  const naturalWidth = ref.current?.naturalWidth;
   useEffect(() => {
-    if (isComplete) {
+    if (ref.current?.complete && ref.current?.naturalWidth !== 0) {
       onLoad();
     }
     if (isLoaded && imgProps.src !== placeholderProps.src) {
       setIsLoaded(false);
     }
-  }, [isLoaded, imgProps.src, placeholderProps.src, isComplete, onLoad]);
+  }, [
+    isLoaded,
+    imgProps.src,
+    placeholderProps.src,
+    complete,
+    naturalWidth,
+    onLoad,
+  ]);
   useEffect(() => {
     // copy the aspect ratio, if we have it, to the extra style reference
     // to allow the BlurhashCanvas to check if there is a fixed aspect ratio

--- a/src/components/ImageLoader/AnyLoader.test.jsx
+++ b/src/components/ImageLoader/AnyLoader.test.jsx
@@ -84,6 +84,73 @@ export const describeAnyLoader = ({
     });
   });
 
+  runPlaceholderExtraStyleTests &&
+    test('shows loaded image if completed', () => {
+      const component = create(
+        <Component
+          src="http://foo.bar/image"
+          alt="DESCRIPTION"
+          placeholder={
+            <>
+              <div foo1="bar1" />
+              <div foo2="bar2" />
+            </>
+          }
+        ></Component>,
+        {
+          createNodeMock: () => ({
+            complete: true,
+            naturalWidth: 800,
+          }),
+        },
+      );
+      act(() => {});
+      const loaded = component.toJSON();
+      expectComponent(loaded, {
+        src: 'http://foo.bar/image',
+        alt: 'DESCRIPTION',
+      });
+    });
+
+  test('shows placeholder if image is completed with error', () => {
+    const component = create(
+      <Component
+        src="http://foo.bar/image"
+        alt="DESCRIPTION"
+        placeholder={
+          <>
+            <div foo1="bar1" />
+            <div foo2="bar2" />
+          </>
+        }
+      ></Component>,
+      {
+        createNodeMock: () => ({
+          complete: true,
+          // naturalWidth will be 0 if the image is not loaded
+          naturalWidth: 0,
+        }),
+      },
+    );
+    const loading = component.toJSON();
+    expect(loading.length).toBe(3);
+    const img = expectWrapper(loading[0]);
+    expect(loading[1].props.foo1).toBe('bar1');
+    expect(loading[2].props.foo2).toBe('bar2');
+    expectComponent(img, {
+      src: 'http://foo.bar/image',
+      alt: 'DESCRIPTION',
+    });
+    act(() => {
+      img.props.onLoad();
+    });
+    const loaded = component.toJSON();
+    expectComponent(loaded, {
+      src: 'http://foo.bar/image',
+      alt: 'DESCRIPTION',
+    });
+  });
+
   describe('shows placeholder if src is missing', () => {
     const testWithSrc = (src) => {
       const component = create(


### PR DESCRIPTION
- Never show broken images, they remain hidden for ever
- If an image is broken, the previous state (placeholder or blurhash) should be shown
- the problem occured if the image was already completed, but with an error in which case the image was shown