### PR TITLE
Fix blurhash width for image content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix blurhash width for image content type @reebalazs
+
 ### Internal
 
 ## 12.3.5 (2022-10-03)

--- a/src/components/ImageLoader/BlurhashCanvas.jsx
+++ b/src/components/ImageLoader/BlurhashCanvas.jsx
@@ -55,6 +55,7 @@ export default ({
   return styleHeight ? (
     <canvas
       style={{
+        width: imgWidth,
         ...style,
         ...placeholderExtraStyleRef?.current,
         height: styleHeight,

--- a/src/components/ImageLoader/BlurhashCanvas.test.jsx
+++ b/src/components/ImageLoader/BlurhashCanvas.test.jsx
@@ -294,6 +294,55 @@ describe('BlurhashCanvas', () => {
       expect(canvas.props.style.height).toBe(50);
     });
 
+    describe('sets width from imgWidth', () => {
+      test('without style', () => {
+        let component;
+        mockCanvas.offsetWidth = 100;
+        const mockPlaceholderExtraStyleRef = { current: {} };
+        act(() => {
+          component = create(
+            <BlurhashCanvas
+              hash="HASH"
+              ratio={2}
+              punch={1}
+              width={32}
+              imgWidth={140}
+              placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
+            />,
+            { createNodeMock: () => mockCanvas },
+          );
+        });
+        const canvas = component.toJSON();
+        expect(canvas.type).toBe('canvas');
+        expect(canvas.children).toBe(null);
+        expect(canvas.props.style.width).toBe(140);
+      });
+
+      test('with style ignored', () => {
+        let component;
+        mockCanvas.offsetWidth = 100;
+        const mockPlaceholderExtraStyleRef = { current: {} };
+        act(() => {
+          component = create(
+            <BlurhashCanvas
+              hash="HASH"
+              ratio={2}
+              punch={1}
+              width={32}
+              imgWidth={140}
+              style={{ width: '100%' }}
+              placeholderExtraStyleRef={mockPlaceholderExtraStyleRef}
+            />,
+            { createNodeMock: () => mockCanvas },
+          );
+        });
+        const canvas = component.toJSON();
+        expect(canvas.type).toBe('canvas');
+        expect(canvas.children).toBe(null);
+        expect(canvas.props.style.width).toBe('100%');
+      });
+    });
+
     test('updates', () => {
       let component;
       mockCanvas.offsetWidth = 100;


### PR DESCRIPTION
Edge case better blurhash loading when we have no `width:100%` which is mainly in the Image content type view, as all other types use a stretched width.