### PR TITLE
Fix /export when some properties are null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix JSON export in some cases with null values. @davisagli
+
 ### Internal
 
 - Update to latest Volto 16 best practices, yarn 3 @sneridagh

--- a/src/server.js
+++ b/src/server.js
@@ -54,7 +54,7 @@ function jsonExporter(req, res, next) {
     })
     .then((content) => {
       return run(
-        `(.. | .href? | arrays | .[]."@id") |= sub("${config.settings.apiPath}";"")`,
+        `(.. | .href? | arrays | .[]."@id" | strings) |= sub("${config.settings.apiPath}";"")`,
         content,
         {
           input: 'json',
@@ -64,7 +64,7 @@ function jsonExporter(req, res, next) {
     })
     .then((content) => {
       return run(
-        `(.. | .preview_image? | arrays | .[]."@id") |= sub("${config.settings.apiPath}";"")`,
+        `(.. | .preview_image? | arrays | .[]."@id" | strings) |= sub("${config.settings.apiPath}";"")`,
         content,
         {
           input: 'json',
@@ -74,7 +74,7 @@ function jsonExporter(req, res, next) {
     })
     .then((content) => {
       return run(
-        `(.. | .url? | arrays | .[]."@id") |= sub("${config.settings.apiPath}";"")`,
+        `(.. | .url? | arrays | .[]."@id" | strings) |= sub("${config.settings.apiPath}";"")`,
         content,
         {
           input: 'json',


### PR DESCRIPTION
Avoids `null (null) cannot be matched, as it is not a string`